### PR TITLE
fix: binance no longer supports depth 1

### DIFF
--- a/include/ccapi_cpp/service/ccapi_market_data_service_binance_base.h
+++ b/include/ccapi_cpp/service/ccapi_market_data_service_binance_base.h
@@ -25,7 +25,7 @@ class MarketDataServiceBinanceBase : public MarketDataService {
     CCAPI_LOGGER_TRACE("conflateIntervalMilliSeconds = " + toString(conflateIntervalMilliSeconds));
     if (field == CCAPI_MARKET_DEPTH) {
       int marketDepthSubscribedToExchange = 1;
-      marketDepthSubscribedToExchange = this->calculateMarketDepthSubscribedToExchange(marketDepthRequested, std::vector<int>({1, 5, 10, 20}));
+      marketDepthSubscribedToExchange = this->calculateMarketDepthSubscribedToExchange(marketDepthRequested, std::vector<int>({5, 10, 20}));
       std::string updateSpeed;
       if (conflateIntervalMilliSeconds < 1000) {
         updateSpeed = "100ms";


### PR DESCRIPTION
depth=1 returns no data. Minimum is now 5.
In accordance with current documentation:
> Top bids and asks, Valid are 5, 10, or 20.

https://binance-docs.github.io/apidocs/spot/en/#all-book-tickers-stream