### PR TITLE
Deribit fix file

### DIFF
--- a/include/ccapi_cpp/service/ccapi_fix_service_deribit.h
+++ b/include/ccapi_cpp/service/ccapi_fix_service_deribit.h
@@ -1,0 +1,70 @@
+#ifndef INCLUDE_CCAPI_CPP_SERVICE_CCAPI_FIX_SERVICE_DERIBIT_H_
+#define INCLUDE_CCAPI_CPP_SERVICE_CCAPI_FIX_SERVICE_DERIBIT_H_
+#ifdef CCAPI_ENABLE_SERVICE_FIX
+#ifdef CCAPI_ENABLE_EXCHANGE_DERIBIT
+#include "ccapi_cpp/ccapi_hmac.h"
+#include "ccapi_cpp/service/ccapi_fix_service.h"
+namespace ccapi {
+class FixServiceDeribit : public FixService<beast::ssl_stream<beast::tcp_stream>>{
+ public:
+  FixServiceDeribit(std::function<void(Event&, Queue<Event>*)> eventHandler, SessionOptions sessionOptions, SessionConfigs sessionConfigs,
+                     ServiceContextPtr serviceContextPtr)
+      : FixService(eventHandler, sessionOptions, sessionConfigs, serviceContextPtr) {
+    CCAPI_LOGGER_FUNCTION_ENTER;
+    this->exchangeName = CCAPI_EXCHANGE_NAME_DERIBIT;
+    this->baseUrlFix = this->sessionConfigs.getUrlFixBase().at(this->exchangeName);
+    this->setHostFixFromUrlFix(this->baseUrlFix);
+    try {
+      this->tcpResolverResultsFix = this->resolver.resolve(this->hostFix, this->portFix);
+    } catch (const std::exception& e) {
+      CCAPI_LOGGER_FATAL(std::string("e.what() = ") + e.what());
+    }
+    this->apiKeyName = CCAPI_DERIBIT_CLIENT_ID;
+    this->apiSecretName = CCAPI_DERIBIT_CLIENT_SECRET;
+    this->setupCredential({this->apiKeyName, this->apiSecretName});
+    this->protocolVersion = CCAPI_FIX_PROTOCOL_VERSION_DERIBIT;
+    this->targetCompID = "Deribit";
+    CCAPI_LOGGER_FUNCTION_EXIT;
+  }
+  virtual ~FixServiceDeribit() {}
+#ifndef CCAPI_EXPOSE_INTERNAL
+
+ protected:
+#endif
+  virtual std::vector<std::pair<int, std::string>> createCommonParam(const std::string& connectionId, const std::string& nowFixTimeStr) {
+    return {
+        {hff::tag::SenderCompID, mapGetWithDefault(this->credentialByConnectionIdMap[connectionId], this->apiKeyName)},
+        {hff::tag::TargetCompID, this->targetCompID},
+        {hff::tag::MsgSeqNum, std::to_string(++this->sequenceSentByConnectionIdMap[connectionId])},
+        {hff::tag::SendingTime, nowFixTimeStr},
+    };
+  }
+  virtual std::vector<std::pair<int, std::string>> createLogonParam(const std::string& connectionId, const std::string& nowFixTimeStr,
+                                                                    const std::map<int, std::string> logonOptionMap = {}) {
+    std::vector<std::pair<int, std::string>> param;
+    auto msgType = "A";
+    param.push_back({hff::tag::MsgType, msgType});
+    param.push_back({hff::tag::EncryptMethod, "0"});
+    param.push_back({hff::tag::HeartBtInt, std::to_string(this->sessionOptions.heartbeatFixIntervalMilliSeconds / 1000)});
+    auto credential = this->credentialByConnectionIdMap[connectionId];
+    auto msgSeqNum = std::to_string(this->sequenceSentByConnectionIdMap[connectionId] + 1);
+    auto senderCompID = mapGetWithDefault(credential, this->apiKeyName);
+    auto targetCompID = this->targetCompID;
+    std::vector<std::string> prehashFieldList{nowFixTimeStr, msgType, msgSeqNum, senderCompID, targetCompID};
+    auto prehashStr = UtilString::join(prehashFieldList, "\x01");
+    CCAPI_LOGGER_TRACE("prehashStr = " + printableString(prehashStr));
+    auto apiSecret = mapGetWithDefault(credential, this->apiSecretName);
+    auto rawData = UtilAlgorithm::base64Encode(Hmac::hmac(Hmac::ShaVersion::SHA256, UtilAlgorithm::base64Decode(apiSecret), prehashStr));
+    CCAPI_LOGGER_TRACE("rawData = " + rawData);
+    param.push_back({hff::tag::RawData, rawData});
+    for (const auto& x : logonOptionMap) {
+      param.push_back({x.first, x.second});
+    }
+    return param;
+  }
+
+};
+} /* namespace ccapi */
+#endif
+#endif
+#endif  // INCLUDE_CCAPI_CPP_SERVICE_CCAPI_FIX_SERVICE_DERIBIT_H_


### PR DESCRIPTION
## Introduction ##
In the directory ` /ccapi/include/ccapi_cpp/service/ ` I have published a file named `ccapi_fix_service_deribit.h ` but I was unable to resolve all the errors in the end.
Deribit needs only two parameters for authentication purposes: _ClientID_ and _ClientSecret_ which I have configured accordingly in the file.
[Deribit FIX API Doc](https://docs.deribit.com/#fix-api)

## Error ##
```
In file included from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_session.h:138:0,
                 from /home/ubuntu/project/options/ccapi/example/src/fix_simple/main.cpp:1:
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h: In constructor ‘ccapi::FixServiceDeribit::FixServiceDeribit(std::function<void(ccapi::Event&, ccapi::Queue<ccapi::Event>*)>, ccapi::SessionOptions, ccapi::SessionConfigs, ccapi::Service::ServiceContextPtr)’:
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h:12:83: error: no matching function for call to ‘ccapi::FixService<boost::beast::ssl_stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::execution::any_executor<boost::asio::execution::context_as_t<boost::asio::execution_context&>, boost::asio::execution::detail::blocking::never_t<0>, boost::asio::execution::prefer_only<boost::asio::execution::detail::blocking::possibly_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::tracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::untracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::fork_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::continuation_t<0> > >, boost::beast::unlimited_rate_policy> > >::FixService(std::function<void(ccapi::Event&, ccapi::Queue<ccapi::Event>*)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, ccapi::Service::ServiceContextPtr&)’
       : FixService(eventHandler, sessionOptions, sessionConfigs, serviceContextPtr) {
                                                                                   ^
In file included from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h:6:0,
                 from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_session.h:138,
                 from /home/ubuntu/project/options/ccapi/example/src/fix_simple/main.cpp:1:
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service.h:11:3: note: candidate: ccapi::FixService<T>::FixService(std::function<void(ccapi::Event&)>, ccapi::SessionOptions, ccapi::SessionConfigs, ccapi::Service::ServiceContextPtr) [with T = boost::beast::ssl_stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::execution::any_executor<boost::asio::execution::context_as_t<boost::asio::execution_context&>, boost::asio::execution::detail::blocking::never_t<0>, boost::asio::execution::prefer_only<boost::asio::execution::detail::blocking::possibly_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::tracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::untracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::fork_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::continuation_t<0> > >, boost::beast::unlimited_rate_policy> >; ccapi::Service::ServiceContextPtr = std::shared_ptr<ccapi::ServiceContext>]
   FixService(std::function<void(Event& event)> eventHandler, SessionOptions sessionOptions, SessionConfigs sessionConfigs, ServiceContextPtr serviceContextPtr)
   ^~~~~~~~~~
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service.h:11:3: note:   no known conversion for argument 1 from ‘std::function<void(ccapi::Event&, ccapi::Queue<ccapi::Event>*)>’ to ‘std::function<void(ccapi::Event&)>’
In file included from /usr/include/x86_64-linux-gnu/c++/7/bits/c++allocator.h:33:0,
                 from /usr/include/c++/7/bits/allocator.h:46,
                 from /usr/include/c++/7/string:41,
                 from /usr/include/c++/7/bits/locale_classes.h:40,
                 from /usr/include/c++/7/bits/ios_base.h:41,
                 from /usr/include/c++/7/iomanip:40,
                 from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_hmac.h:43,
                 from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h:5,
                 from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_session.h:138,
                 from /home/ubuntu/project/options/ccapi/example/src/fix_simple/main.cpp:1:
/usr/include/c++/7/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = ccapi::FixServiceDeribit; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; _Tp = ccapi::FixServiceDeribit]’:
/usr/include/c++/7/bits/alloc_traits.h:475:4:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = ccapi::FixServiceDeribit; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; _Tp = ccapi::FixServiceDeribit; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<ccapi::FixServiceDeribit>]’
/usr/include/c++/7/bits/shared_ptr_base.h:526:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; _Tp = ccapi::FixServiceDeribit; _Alloc = std::allocator<ccapi::FixServiceDeribit>; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/include/c++/7/bits/shared_ptr_base.h:637:4:   required from ‘std::__shared_count<_Lp>::__shared_count(std::_Sp_make_shared_tag, _Tp*, const _Alloc&, _Args&& ...) [with _Tp = ccapi::FixServiceDeribit; _Alloc = std::allocator<ccapi::FixServiceDeribit>; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/include/c++/7/bits/shared_ptr_base.h:1295:35:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_make_shared_tag, const _Alloc&, _Args&& ...) [with _Alloc = std::allocator<ccapi::FixServiceDeribit>; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; _Tp = ccapi::FixServiceDeribit; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/include/c++/7/bits/shared_ptr.h:344:64:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_make_shared_tag, const _Alloc&, _Args&& ...) [with _Alloc = std::allocator<ccapi::FixServiceDeribit>; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}; _Tp = ccapi::FixServiceDeribit]’
/usr/include/c++/7/bits/shared_ptr.h:690:14:   required from ‘std::shared_ptr<_Tp> std::allocate_shared(const _Alloc&, _Args&& ...) [with _Tp = ccapi::FixServiceDeribit; _Alloc = std::allocator<ccapi::FixServiceDeribit>; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}]’
/usr/include/c++/7/bits/shared_ptr.h:706:39:   required from ‘std::shared_ptr<_Tp> std::make_shared(_Args&& ...) [with _Tp = ccapi::FixServiceDeribit; _Args = {std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&}]’
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_session.h:360:128:   required from here
/usr/include/c++/7/ext/new_allocator.h:136:4: error: no matching function for call to ‘ccapi::FixServiceDeribit::FixServiceDeribit(std::function<void(ccapi::Event&)>&, ccapi::SessionOptions&, ccapi::SessionConfigs&, std::shared_ptr<ccapi::ServiceContext>&)’
  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/ubuntu/project/options/ccapi/include/ccapi_cpp/ccapi_session.h:138:0,
                 from /home/ubuntu/project/options/ccapi/example/src/fix_simple/main.cpp:1:
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h:10:3: note: candidate: ccapi::FixServiceDeribit::FixServiceDeribit(std::function<void(ccapi::Event&, ccapi::Queue<ccapi::Event>*)>, ccapi::SessionOptions, ccapi::SessionConfigs, ccapi::Service::ServiceContextPtr)
   FixServiceDeribit(std::function<void(Event&, Queue<Event>*)> eventHandler, SessionOptions sessionOptions, SessionConfigs sessionConfigs,
   ^~~~~~~~~~~~~~~~~
/home/ubuntu/project/options/ccapi/include/ccapi_cpp/service/ccapi_fix_service_deribit.h:10:3: note:   no known conversion for argument 1 from ‘std::function<void(ccapi::Event&)>’ to ‘std::function<void(ccapi::Event&, ccapi::Queue<ccapi::Event>*)>’
src/fix_simple/CMakeFiles/fix_simple.dir/build.make:75: recipe for target 'src/fix_simple/CMakeFiles/fix_simple.dir/main.cpp.o' failed
make[2]: *** [src/fix_simple/CMakeFiles/fix_simple.dir/main.cpp.o] Error 1
CMakeFiles/Makefile2:601: recipe for target 'src/fix_simple/CMakeFiles/fix_simple.dir/all' failed
make[1]: *** [src/fix_simple/CMakeFiles/fix_simple.dir/all] Error 2
Makefile:90: recipe for target 'all' failed
make: *** [all] Error 2
```