### PR TITLE
Only delete eventDispatcher when useInternalEventDispatcher is true

### DIFF
--- a/include/ccapi_cpp/ccapi_session.h
+++ b/include/ccapi_cpp/ccapi_session.h
@@ -228,7 +228,9 @@ class Session {
   }
   virtual ~Session() {
     CCAPI_LOGGER_FUNCTION_ENTER;
-    delete this->eventDispatcher;
+    if (this->useInternalEventDispatcher) {
+      delete this->eventDispatcher;
+    }
     CCAPI_LOGGER_FUNCTION_EXIT;
   }
   virtual void start() {


### PR DESCRIPTION
PR to address issue #274. Session class was deleting its eventDispatcher even when it had been passed to the session at construction.