### PR TITLE
huobi allow custom values of the field 'type'

### DIFF
--- a/include/ccapi_cpp/service/ccapi_execution_management_service_huobi_base.h
+++ b/include/ccapi_cpp/service/ccapi_execution_management_service_huobi_base.h
@@ -79,7 +79,8 @@ class ExecutionManagementServiceHuobiBase : public ExecutionManagementService {
         }
       } else {
         if (key == "type") {
-          value = (value == CCAPI_EM_ORDER_SIDE_BUY || value == "buy-limit") ? "buy-limit" : "sell-limit";
+          if (value == CCAPI_EM_ORDER_SIDE_BUY) value = "buy-limit";
+          else if (value == CCAPI_EM_ORDER_SIDE_SELL) value = "sell-limit";
         }
       }
       document.AddMember(rj::Value(key.c_str(), allocator).Move(), rj::Value(value.c_str(), allocator).Move(), allocator);


### PR DESCRIPTION
With this patch, it can send orders with a custom type, like buy-ioc or buy-limit-fok