### PR TITLE
Fix for an error while compiling with MSVC 2022 + Boost 1.81

### DIFF
--- a/include/ccapi_cpp/service/ccapi_service.h
+++ b/include/ccapi_cpp/service/ccapi_service.h
@@ -593,7 +593,12 @@ class Service : public std::enable_shared_from_this<Service> {
         this->processSuccessfulTextMessageRest(statusCode, request, body, now, eventQueuePtr);
       } else if (statusCode / 100 == 3) {
         if (resPtr->base().find("Location") != resPtr->base().end()) {
-          Url url(resPtr->base().at("Location"));
+          Url url(resPtr->base().at("Location")
+#if BOOST_VERSION < 108100
+              // Boost Beast 1.81 uses boost::core::string_view which doesn't contain to_string() method
+              .to_string()
+#endif
+          );
           std::string host(url.host);
           if (!url.port.empty()) {
             host += ":";

--- a/include/ccapi_cpp/service/ccapi_service.h
+++ b/include/ccapi_cpp/service/ccapi_service.h
@@ -593,7 +593,7 @@ class Service : public std::enable_shared_from_this<Service> {
         this->processSuccessfulTextMessageRest(statusCode, request, body, now, eventQueuePtr);
       } else if (statusCode / 100 == 3) {
         if (resPtr->base().find("Location") != resPtr->base().end()) {
-          Url url(resPtr->base().at("Location").to_string());
+          Url url(resPtr->base().at("Location"));
           std::string host(url.host);
           if (!url.port.empty()) {
             host += ":";


### PR DESCRIPTION
I propose this pull request to fix the following error while compiling with MSVC 2022 + Boost 1.81:

```
3>E:\DevTools\ccapi\include\ccapi_cpp/service/ccapi_service.h(596,49): error C2039: 'to_string': is not a member of 'boost::core::basic_string_view<char>'
3>E:/DevTools/boost_1_81_0\boost/core/detail/string_view.hpp(1229,9): message : see declaration of 'boost::core::basic_string_view<char>'
```