### PR TITLE
Add missing #include <iterator>

### DIFF
--- a/include/ccapi_cpp/ccapi_util_private.h
+++ b/include/ccapi_cpp/ccapi_util_private.h
@@ -12,6 +12,7 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <numeric>
 #include <random>


### PR DESCRIPTION
This PR adds a missing `#include <iterator>` that fixes compiling with g++ as described here https://github.com/crypto-chassis/ccapi/issues/402