### PR TITLE
fix: Prevent out-of-bounds access in ceilSearch function

### DIFF
--- a/include/ccapi_cpp/ccapi_util_private.h
+++ b/include/ccapi_cpp/ccapi_util_private.h
@@ -732,7 +732,7 @@ int ceilSearch(const std::vector<T>& c, int low, int high, T x) {
   if (x <= c[low]) {
     return low;
   }
-  for (i = low; i < high; i++) {
+  for (i = low; i < high - 1; i++) {
     if (c[i] == x) {
       return i;
     }


### PR DESCRIPTION
I've noticed that when subscribing to an instrument and specifying the depth of the order book that you would like to be updated on, the **calculateMarketDepthAllowedByExchange** function gets called with a vector of the actually possible depths the exchange offers. This function then utilizes the **ceilSearch** function to determine the closest greatest market depth allowed by the exchange to the _depthWanted_.

In the current implementation, there is a potential issue where the function may iterate beyond the last element of the vector if the desired market depth exceeds the greatest market depth offered by the exchange. 

Will leave screenshots as an attachment.

 **
![Screenshot from 2024-05-15 20-41-02](https://github.com/crypto-chassis/ccapi/assets/78508013/8ebd186f-843e-427f-a2cb-984770ac3d79)
![Screenshot from 2024-05-15 20-43-45](https://github.com/crypto-chassis/ccapi/assets/78508013/e4c14fe6-b337-4f74-893e-eedc85fec317)**