### PR TITLE
Fix rapidjson when using newer compilers (g++14 onwards)

### DIFF
--- a/binding/CMakeLists.txt
+++ b/binding/CMakeLists.txt
@@ -122,7 +122,7 @@ if(NOT CCAPI_LEGACY_USE_WEBSOCKETPP)
     include(ExternalProject)
     ExternalProject_Add(
       rapidjson
-      URL https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz
+      URL https://github.com/Tencent/rapidjson/archive/3b2441b87f99ab65f37b141a7b548ebadb607b96.tar.gz
       SOURCE_DIR "${CMAKE_BINARY_DIR}/rapidjson"
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT RAPIDJSON_INCLUDE_DIR)
   include(ExternalProject)
   ExternalProject_Add(
     rapidjson
-    URL https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz
+    URL https://github.com/Tencent/rapidjson/archive/3b2441b87f99ab65f37b141a7b548ebadb607b96.tar.gz
     SOURCE_DIR "${CMAKE_BINARY_DIR}/rapidjson"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
It points to the next commit after the last tag done in the project that fixes the GenericStringRef::operator=. See
https://github.com/Tencent/rapidjson/issues/718 for more context.