### PR TITLE
Implement order book checksum in kraken

### DIFF
--- a/include/ccapi_cpp/ccapi_util_private.h
+++ b/include/ccapi_cpp/ccapi_util_private.h
@@ -958,7 +958,7 @@ class Decimal {
     }
   }
 
-  explicit Decimal(std::string_view originalValue) {
+  explicit Decimal(std::string_view originalValue, bool checksumEnabled=false) {
     if (originalValue.empty()) {
       throw std::invalid_argument("Decimal constructor input value cannot be empty");
     }
@@ -972,7 +972,7 @@ class Decimal {
       }
       std::string fixedPointValue = std::string(originalValue.substr(this->sign ? 0 : 1, this->sign ? foundE : foundE - 1));
       auto foundDot = fixedPointValue.find('.');
-      if (foundDot != std::string::npos) {
+      if (foundDot != std::string::npos and not checksumEnabled) {
         fixedPointValue.erase(fixedPointValue.find_last_not_of('0') + 1);
         fixedPointValue.erase(fixedPointValue.find_last_not_of('.') + 1);
       }
@@ -1017,9 +1017,9 @@ class Decimal {
       }
       if (foundDot != std::string::npos) {
         this->frac = fixedPointValue.substr(foundDot + 1);
-        // if (!keepTrailingZero) {
-        this->frac.erase(this->frac.find_last_not_of('0') + 1);
-        // }
+        if (!checksumEnabled) {
+          this->frac.erase(this->frac.find_last_not_of('0') + 1);
+        }
       }
     } else {
       auto found = originalValue.find('.');
@@ -1033,9 +1033,9 @@ class Decimal {
       }
       if (found != std::string::npos) {
         this->frac = originalValue.substr(found + 1);
-        // if (!keepTrailingZero) {
-        this->frac.erase(this->frac.find_last_not_of('0') + 1);
-        // }
+        if (not checksumEnabled) {
+          this->frac.erase(this->frac.find_last_not_of('0') + 1);
+        }
       }
     }
 

--- a/include/ccapi_cpp/service/ccapi_market_data_service.h
+++ b/include/ccapi_cpp/service/ccapi_market_data_service.h
@@ -804,7 +804,7 @@ class MarketDataService : public Service {
         for (auto& y : detail) {
           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-          Decimal decimalPrice(price);
+          Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
           snapshotBid.emplace(decimalPrice, std::string(size));
         }
         CCAPI_LOGGER_TRACE("lastNToString(snapshotBid, " + toString(maxMarketDepth) + ") = " + lastNToString(snapshotBid, maxMarketDepth));
@@ -812,7 +812,7 @@ class MarketDataService : public Service {
         for (auto& y : detail) {
           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-          Decimal decimalPrice(price);
+          Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
           snapshotAsk.emplace(decimalPrice, std::string(size));
         }
         CCAPI_LOGGER_TRACE("firstNToString(snapshotAsk, " + toString(maxMarketDepth) + ") = " + firstNToString(snapshotAsk, maxMarketDepth));
@@ -894,14 +894,14 @@ class MarketDataService : public Service {
           for (auto& y : detail) {
             const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
             const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-            Decimal decimalPrice(price);
+            Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
             this->updateOrderBook(snapshotBid, decimalPrice, size, this->sessionOptions.enableCheckOrderBookChecksum);
           }
         } else if (type == MarketDataMessage::DataType::ASK) {
           for (auto& y : detail) {
             const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
             const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-            Decimal decimalPrice(price);
+            Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
             this->updateOrderBook(snapshotAsk, decimalPrice, size, this->sessionOptions.enableCheckOrderBookChecksum);
           }
         } else {
@@ -1098,7 +1098,7 @@ class MarketDataService : public Service {
               this->highByConnectionIdChannelIdSymbolIdMap[wsConnectionPtr->id][channelId][symbolId] = Decimal(price);
               this->lowByConnectionIdChannelIdSymbolIdMap[wsConnectionPtr->id][channelId][symbolId] = Decimal(price);
             } else {
-              Decimal decimalPrice(price);
+              Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
               if (decimalPrice > this->highByConnectionIdChannelIdSymbolIdMap[wsConnectionPtr->id][channelId][symbolId]) {
                 this->highByConnectionIdChannelIdSymbolIdMap[wsConnectionPtr->id][channelId][symbolId] = decimalPrice;
               }
@@ -1372,7 +1372,7 @@ class MarketDataService : public Service {
         for (auto& y : detail) {
           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-          Decimal decimalPrice(price);
+          Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
           snapshotBid.emplace(decimalPrice, std::string(size));
         }
         CCAPI_LOGGER_TRACE("lastNToString(snapshotBid, " + toString(maxMarketDepth) + ") = " + lastNToString(snapshotBid, maxMarketDepth));
@@ -1380,7 +1380,7 @@ class MarketDataService : public Service {
         for (auto& y : detail) {
           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-          Decimal decimalPrice(price);
+          Decimal decimalPrice(price, this->sessionOptions.enableCheckOrderBookChecksum);
           snapshotAsk.emplace(decimalPrice, std::string(size));
         }
         CCAPI_LOGGER_TRACE("firstNToString(snapshotAsk, " + toString(maxMarketDepth) + ") = " + firstNToString(snapshotAsk, maxMarketDepth));
@@ -1520,14 +1520,14 @@ class MarketDataService : public Service {
                     for (const auto& y : detail) {
                       const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
                       const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-                      Decimal decimalPrice(price);
+                      Decimal decimalPrice(price, that->sessionOptions.enableCheckOrderBookChecksum);
                       snapshotBid.emplace(decimalPrice, std::string(size));
                     }
                   } else if (type == MarketDataMessage::DataType::ASK) {
                     for (const auto& y : detail) {
                       const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
                       const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-                      Decimal decimalPrice(price);
+                      Decimal decimalPrice(price, that->sessionOptions.enableCheckOrderBookChecksum);
                       snapshotAsk.emplace(decimalPrice, std::string(size));
                     }
                   }
@@ -1548,14 +1548,14 @@ class MarketDataService : public Service {
                         for (const auto& y : detail) {
                           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
                           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-                          Decimal decimalPrice(price);
+                          Decimal decimalPrice(price, that->sessionOptions.enableCheckOrderBookChecksum);
                           that->updateOrderBook(snapshotBid, decimalPrice, size, that->sessionOptions.enableCheckOrderBookChecksum);
                         }
                       } else if (type == MarketDataMessage::DataType::ASK) {
                         for (const auto& y : detail) {
                           const auto& price = y.at(MarketDataMessage::DataFieldType::PRICE);
                           const auto& size = y.at(MarketDataMessage::DataFieldType::SIZE);
-                          Decimal decimalPrice(price);
+                          Decimal decimalPrice(price, that->sessionOptions.enableCheckOrderBookChecksum);
                           that->updateOrderBook(snapshotAsk, decimalPrice, size, that->sessionOptions.enableCheckOrderBookChecksum);
                         }
                       }
@@ -1671,6 +1671,7 @@ class MarketDataService : public Service {
                                   Event& event, std::vector<MarketDataMessage>& marketDataMessageList) {}
 
   virtual std::string calculateOrderBookChecksum(const std::map<Decimal, std::string>& snapshotBid, const std::map<Decimal, std::string>& snapshotAsk) {
+    CCAPI_LOGGER_DEBUG("calculateOrderBookChecksum is not implemented for this exchange");
     return {};
   }
 

--- a/include/ccapi_cpp/service/ccapi_market_data_service_kraken.h
+++ b/include/ccapi_cpp/service/ccapi_market_data_service_kraken.h
@@ -50,6 +50,47 @@ class MarketDataServiceKraken : public MarketDataService {
     }
   }
 
+  static void processForChecksum(std::string& str) {
+    str.erase(std::remove(str.begin(), str.end(), '.'), str.end());
+    UtilString::ltrimInPlace(str, "0");
+  }
+
+  std::vector<std::string> extractTop(const std::map<Decimal, std::string>& snapshot, bool reverse = false) {
+    std::vector<std::string> result;
+    int count = 0;
+
+    auto process_item = [&](auto it) {
+        std::string price = toString(it->first);
+        processForChecksum(price);
+        result.push_back(std::move(price));
+
+        std::string volume = it->second;
+        processForChecksum(volume);
+        result.push_back(std::move(volume));
+    };
+
+    if (reverse) {
+        for (auto it = snapshot.rbegin(); it != snapshot.rend() && count < 10; ++it, ++count) {
+            process_item(it);
+        }
+    } else {
+        for (auto it = snapshot.begin(); it != snapshot.end() && count < 10; ++it, ++count) {
+            process_item(it);
+        }
+    }
+    return result;
+  };
+
+  std::string calculateOrderBookChecksum(const std::map<Decimal, std::string>& snapshotBid, const std::map<Decimal, std::string>& snapshotAsk) override {
+    auto csAskData = extractTop(snapshotAsk);
+    auto csBidData = extractTop(snapshotBid, true);
+
+    std::string csStr = UtilString::join(csAskData, "") + UtilString::join(csBidData, "");
+    uint_fast32_t csCalc = UtilAlgorithm::crc(csStr.begin(), csStr.end());
+    CCAPI_LOGGER_DEBUG("csStr: " + csStr + ", csCalc: " + intToHex(csCalc));
+    return intToHex(csCalc);
+  }
+
   std::vector<std::string> createSendStringList(std::shared_ptr<WsConnection> wsConnectionPtr) override {
     std::vector<std::string> sendStringList;
     for (const auto& subscriptionListByChannelIdSymbolId : this->subscriptionListByConnectionIdChannelIdSymbolIdMap.at(wsConnectionPtr->id)) {
@@ -186,19 +227,26 @@ class MarketDataServiceKraken : public MarketDataService {
           marketDataMessage.exchangeSubscriptionId = exchangeSubscriptionId;
           marketDataMessage.tp = latestTp;
           marketDataMessage.recapType = MarketDataMessage::RecapType::NONE;
+          if (this->sessionOptions.enableCheckOrderBookChecksum) {
+            if (anonymous2.HasMember("c")) {
+              CCAPI_LOGGER_DEBUG("Checksum for " + symbolId + ": " + anonymous2["c"].GetString());
+              this->orderBookChecksumByConnectionIdSymbolIdMap[wsConnectionPtr->id][symbolId] =
+                                          intToHex(static_cast<uint_fast32_t>(static_cast<uint32_t>(std::stoul(anonymous2["c"].GetString()))));
+            }
+          }
           if (anonymous2.HasMember("b")) {
             for (const auto& x : anonymous2["b"].GetArray()) {
               MarketDataMessage::TypeForDataPoint dataPoint;
-              dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-              dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+              dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+              dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
               marketDataMessage.data[MarketDataMessage::DataType::BID].emplace_back(std::move(dataPoint));
             }
           }
           if (anonymous2.HasMember("a")) {
             for (const auto& x : anonymous2["a"].GetArray()) {
               MarketDataMessage::TypeForDataPoint dataPoint;
-              dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-              dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+              dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+              dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
               marketDataMessage.data[MarketDataMessage::DataType::ASK].emplace_back(std::move(dataPoint));
             }
           }
@@ -211,14 +259,14 @@ class MarketDataServiceKraken : public MarketDataService {
           marketDataMessage.tp = timeReceived;
           for (const auto& x : anonymous["bs"].GetArray()) {
             MarketDataMessage::TypeForDataPoint dataPoint;
-            dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-            dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+            dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+            dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
             marketDataMessage.data[MarketDataMessage::DataType::BID].emplace_back(std::move(dataPoint));
           }
           for (const auto& x : anonymous["as"].GetArray()) {
             MarketDataMessage::TypeForDataPoint dataPoint;
-            dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-            dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+            dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+            dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
             marketDataMessage.data[MarketDataMessage::DataType::ASK].emplace_back(std::move(dataPoint));
           }
           marketDataMessageList.emplace_back(std::move(marketDataMessage));
@@ -235,8 +283,8 @@ class MarketDataServiceKraken : public MarketDataService {
           tp += std::chrono::nanoseconds(timePair.second);
           marketDataMessage.tp = tp;
           MarketDataMessage::TypeForDataPoint dataPoint;
-          dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-          dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+          dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+          dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
           dataPoint.emplace(MarketDataMessage::DataFieldType::IS_BUYER_MAKER, std::string_view(x[3].GetString()) == "s" ? "1" : "0");
           marketDataMessage.data[MarketDataMessage::DataType::TRADE].emplace_back(std::move(dataPoint));
           marketDataMessageList.emplace_back(std::move(marketDataMessage));
@@ -372,8 +420,8 @@ class MarketDataServiceKraken : public MarketDataService {
           tp += std::chrono::nanoseconds(timePair.second);
           marketDataMessage.tp = tp;
           MarketDataMessage::TypeForDataPoint dataPoint;
-          dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, UtilString::normalizeDecimalStringView(x[0].GetString()));
-          dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, UtilString::normalizeDecimalStringView(x[1].GetString()));
+          dataPoint.emplace(MarketDataMessage::DataFieldType::PRICE, x[0].GetString());
+          dataPoint.emplace(MarketDataMessage::DataFieldType::SIZE, x[1].GetString());
           dataPoint.emplace(MarketDataMessage::DataFieldType::IS_BUYER_MAKER, std::string_view(x[3].GetString()) == "s" ? "1" : "0");
           marketDataMessage.data[MarketDataMessage::DataType::TRADE].emplace_back(std::move(dataPoint));
           marketDataMessageList.emplace_back(std::move(marketDataMessage));


### PR DESCRIPTION
I have implemented calculateOrderBookChecksum for kraken using the following
```
diff --git a/example/src/market_data_simple_subscription/CMakeLists.txt b/example/src/market_data_simple_subscription/CMakeLists.txt
index c72cc750..69a58c0f 100644
--- a/example/src/market_data_simple_subscription/CMakeLists.txt
+++ b/example/src/market_data_simple_subscription/CMakeLists.txt
@@ -2,5 +2,6 @@ set(NAME market_data_simple_subscription)
 project(${NAME})
 add_compile_definitions(CCAPI_ENABLE_SERVICE_MARKET_DATA)
 add_compile_definitions(CCAPI_ENABLE_EXCHANGE_OKX)
+add_compile_definitions(CCAPI_ENABLE_EXCHANGE_KRAKEN)
 add_executable(${NAME} main.cpp)
 add_dependencies(${NAME} boost rapidjson)
diff --git a/example/src/market_data_simple_subscription/main.cpp b/example/src/market_data_simple_subscription/main.cpp
index ca9eff16..018fff20 100644
--- a/example/src/market_data_simple_subscription/main.cpp
+++ b/example/src/market_data_simple_subscription/main.cpp
@@ -36,10 +36,11 @@ int main(int argc, char** argv) {
   SessionOptions sessionOptions;
   SessionConfigs sessionConfigs;
   MyEventHandler eventHandler;
+  sessionOptions.enableCheckOrderBookChecksum = true;
   Session session(sessionOptions, sessionConfigs, &eventHandler);
-  Subscription subscription("okx", "BTC-USDT", "MARKET_DEPTH");
+  Subscription subscription("kraken", "ETH/USDT", "MARKET_DEPTH", "MARKET_DEPTH_MAX=20", "any");
   session.subscribe(subscription);
-  std::this_thread::sleep_for(std::chrono::seconds(10));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   session.stop();
   std::cout << "Bye" << std::endl;
   return EXIT_SUCCESS;
```
as example. The output [log.txt](https://github.com/user-attachments/files/21755077/log.txt)
