### PR TITLE
refactor: include inflate stream only when needed

### DIFF
--- a/include/ccapi_cpp/service/ccapi_service.h
+++ b/include/ccapi_cpp/service/ccapi_service.h
@@ -27,6 +27,12 @@
 #define CCAPI_WEBSOCKET_WRITE_BUFFER_SIZE (1 << 20)
 #endif
 
+#define CCAPI_REQUIRES_INFLATE_STREAM                                                                                                              \
+  ((defined(CCAPI_ENABLE_SERVICE_MARKET_DATA) &&                                                                                                   \
+    (defined(CCAPI_ENABLE_EXCHANGE_HUOBI) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP))) || \
+   (defined(CCAPI_ENABLE_SERVICE_EXECUTION_MANAGEMENT) &&                                                                                          \
+    (defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_BITMART))))
+
 #include <regex>
 
 #include "boost/asio/strand.hpp"
@@ -50,7 +56,9 @@
 #include "ccapi_cpp/ccapi_fix_connection.h"
 #include "ccapi_cpp/ccapi_http_connection.h"
 #include "ccapi_cpp/ccapi_http_retry.h"
+#if CCAPI_REQUIRES_INFLATE_STREAM
 #include "ccapi_cpp/ccapi_inflate_stream.h"
+#endif
 #include "ccapi_cpp/ccapi_queue.h"
 #include "ccapi_cpp/ccapi_request.h"
 #include "ccapi_cpp/ccapi_session_configs.h"
@@ -1437,10 +1445,7 @@ class Service : public std::enable_shared_from_this<Service> {
           } else if (stream.got_binary()) {
             CCAPI_LOGGER_DEBUG("received a binary message: " + UtilAlgorithm::stringToHex(std::string(data, dataSize)));
 
-#if defined(CCAPI_ENABLE_SERVICE_MARKET_DATA) &&                                                                                                      \
-        (defined(CCAPI_ENABLE_EXCHANGE_HUOBI) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP)) || \
-    defined(CCAPI_ENABLE_SERVICE_EXECUTION_MANAGEMENT) &&                                                                                             \
-        (defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_BITMART))
+#if CCAPI_REQUIRES_INFLATE_STREAM
 
             if (this->needDecompressWebsocketMessage) {
               std::string decompressed;
@@ -1660,13 +1665,8 @@ class Service : public std::enable_shared_from_this<Service> {
   // std::regex convertNumberToStringInJsonRegex{"(\\[|,|\":)\\s?(-?\\d+\\.?\\d*)"};
   // std::string convertNumberToStringInJsonRewrite{"$1\"$2\""};
   bool needDecompressWebsocketMessage{};
-#if defined(CCAPI_ENABLE_SERVICE_MARKET_DATA) &&                                                                                                      \
-        (defined(CCAPI_ENABLE_EXCHANGE_HUOBI) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP)) || \
-    defined(CCAPI_ENABLE_SERVICE_EXECUTION_MANAGEMENT) &&                                                                                             \
-        (defined(CCAPI_ENABLE_EXCHANGE_HUOBI_USDT_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_HUOBI_COIN_SWAP) || defined(CCAPI_ENABLE_EXCHANGE_BITMART))
-
+#if CCAPI_REQUIRES_INFLATE_STREAM
   InflateStream inflater;
-
 #endif
 
   std::array<char, CCAPI_JSON_PARSE_BUFFER_SIZE> jsonParseBuffer;


### PR DESCRIPTION
`ccapi_inflate_stream.h` was included unconditionally even though it’s only used for specific exchanges, making zlib a hard dependency. Guard the include so zlib is required only when relevant; also replace the duplicated conditions with a shared macro for reuse.